### PR TITLE
Fixed hanging output

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/lesnuages/go-execute-assembly/assembly"
+	"github.com/djhohnstein/go-execute-assembly/assembly"
 )
 
 func main() {


### PR DESCRIPTION
Now uses the thread handle from CreateRemoteThread to continuously query the thread state until it exits. Probably needs an edit for the package imports in main.